### PR TITLE
npmreserve 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![npmreserve](http://i.imgur.com/67mKyws.png)](#)
 
-# `$ npmreserve` [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/npmreserve.svg)](https://www.npmjs.com/package/npmreserve) [![Downloads](https://img.shields.io/npm/dt/npmreserve.svg)](https://www.npmjs.com/package/npmreserve) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# `$ npmreserve`
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/npmreserve.svg)](https://www.npmjs.com/package/npmreserve) [![Downloads](https://img.shields.io/npm/dt/npmreserve.svg)](https://www.npmjs.com/package/npmreserve) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Reserve package names on NPM.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npmreserve",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Reserve package names on NPM.",
   "main": "lib/index.js",
   "bin": {
@@ -67,6 +67,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
 - Updated the README.md following the new template. :memo:
 - Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.